### PR TITLE
Allow filter/replace on IDs without a description.

### DIFF
--- a/seqmagick/subcommands/convert.py
+++ b/seqmagick/subcommands/convert.py
@@ -159,11 +159,11 @@ def add_options(parser):
     seq_select.add_argument('--pattern-include', metavar='REGEX',
             action=partial_action(transform.name_include, 'filter_regex'),
             dest='transforms', help="""Filter the sequences by regular
-            expression in name""")
+            expression in ID or description""")
     seq_select.add_argument('--pattern-exclude', metavar='REGEX',
             action=partial_action(transform.name_exclude, 'filter_regex'),
             dest='transforms', help="""Filter the sequences by regular
-            expression in name""")
+            expression in ID or description""")
     seq_select.add_argument('--prune-empty',
             action=partial_action(transform.prune_empty), dest='transforms',
             help="Prune sequences containing only gaps ('-')")
@@ -199,7 +199,7 @@ def add_options(parser):
             action=partial_action(transform.name_replace, ('search_regex',
                 'replace_pattern')),
             dest='transforms', help="""Replace regex pattern "search_pattern"
-            with "replace_pattern" in sequence identifier""")
+            with "replace_pattern" in sequence ID and description""")
     id_mods.add_argument('--strip-range', dest='transforms',
             action=partial_action(transform.strip_range), help="""Strip ranges
             from sequences IDs, matching </x-y>""")

--- a/seqmagick/test/test_transform.py
+++ b/seqmagick/test/test_transform.py
@@ -44,45 +44,80 @@ class PatternReplaceTestCase(unittest.TestCase):
     def tearDown(self):
         super(PatternReplaceTestCase, self).tearDown()
 
-    def test_pattern_replace_anchored_match_id_only(self):
-        sequences = [seqrecord('hello', 'A', description='hello friend')]
-        transformed = next(transform.name_replace(sequences, '^hello$', 'bye'))
+    # from http://stackoverflow.com/questions/13923072/shortening-fasta-header-perl
+    def test_pattern_replace_anchored_transform_id(self):
+        sequences = [seqrecord('gi|351517969|ref|NW_003613580.1|', 'CAGTC',
+                               description='gi|351517969|ref|NW_003613580.1| Cricetulus griseus unplaced genomic scaffold'),
+                    seqrecord('gi|351517969|ref|NW_003613580.1|', 'CAGTC',
+                               description='gi|351517969|ref|NW_003613580.1|'),
+                    seqrecord('gi|351517969|ref|NW_003613580.1|', 'CAGTC')]
+
+        # capture the identifier after three groups of pipe-separated characters
+        transformed = list(transform.name_replace(sequences, r'^(?:[^|]+\|){3}([^|]+)\|', r'\1'))
+
+        self.assertEqual(str(sequences[0].seq), str(transformed[0].seq))
+        self.assertEqual('NW_003613580.1', transformed[0].id)
+        self.assertEqual('NW_003613580.1 Cricetulus griseus unplaced genomic scaffold', transformed[0].description)
+
+        self.assertEqual(str(sequences[1].seq), str(transformed[1].seq))
+        self.assertEqual('NW_003613580.1', transformed[1].id)
+        self.assertEqual('NW_003613580.1', transformed[1].description)
+
+        self.assertEqual(str(sequences[2].seq), str(transformed[2].seq))
+        self.assertEqual('NW_003613580.1', transformed[2].id)
+        self.assertEqual('<unknown description>', transformed[2].description)
+
+    # from http://stackoverflow.com/questions/15155728/modifying-fasta-headers-with-unix-command-line-tools
+    def test_pattern_replace_anchored_id_from_description(self):
+        sequences = [seqrecord('hg19_ct_UserTrack_3545_691', 'GATGG',
+                               description='hg19_ct_UserTrack_3545_691 range=chr1:8121498-8121502 5\'pad=0 3\'pad=0 strand=+ repeatMasking=none')]
+
+        transformed = next(transform.name_replace(sequences, r'^\S+ range=(\S+)', r'\1'))
 
         self.assertEqual(str(sequences[0].seq), str(transformed.seq))
-        self.assertEqual('bye', transformed.id)
-        self.assertEqual('bye friend', transformed.description)
+        self.assertEqual('chr1:8121498-8121502', transformed.id)
+        self.assertEqual('chr1:8121498-8121502 5\'pad=0 3\'pad=0 strand=+ repeatMasking=none', transformed.description)
 
-    def test_pattern_replace_anchored_match_description_only(self):
-        sequences = [seqrecord('hello', 'A', description='hello friend')]
-        transformed = next(transform.name_replace(sequences, '^friend$', 'buddy'))
+    # from http://stackoverflow.com/questions/23280240/how-to-rename-fasta-file-headers-using-sed
+    def test_pattern_replace_anchored_add_to_description(self):
+        sequences = [seqrecord('Bra000001', 'CTTAT', description='Bra000001')]
 
-        self.assertEqual(str(sequences[0].seq), str(transformed.seq))
-        self.assertEqual('hello', transformed.id)
-        self.assertEqual('hello buddy', transformed.description)
-
-    def test_pattern_replace_anchored_match_both(self):
-        sequences = [seqrecord('hello', 'A', description='hello hello friend')]
-        transformed = next(transform.name_replace(sequences, r'^hello\b', 'bye'))
+        transformed = next(transform.name_replace(sequences, r'^(Bra\d+)$', r'\1 Brassica rapa'))
 
         self.assertEqual(str(sequences[0].seq), str(transformed.seq))
-        self.assertEqual('bye', transformed.id)
-        self.assertEqual('bye bye friend', transformed.description)
+        self.assertEqual('Bra000001', transformed.id)
+        self.assertEqual('Bra000001 Brassica rapa', transformed.description)
 
-    def test_pattern_replace_anchored_match_neither(self):
+    def test_pattern_replace_anchored_remove_from_description(self):
+        sequences = [seqrecord('Bra000001', 'CTTAT', description='Bra000001 Brassica rapa')]
+
+        transformed = next(transform.name_replace(sequences, r' .*$', ''))
+
+        self.assertEqual(str(sequences[0].seq), str(transformed.seq))
+        self.assertEqual('Bra000001', transformed.id)
+        self.assertEqual('Bra000001', transformed.description)
+
+    def test_pattern_replace_anchored_nomatch(self):
         sequences = [seqrecord('hello', 'A', description='hello friend')]
-        transformed = next(transform.name_replace(sequences, r'^hello friend', 'bye'))
+        transformed = next(transform.name_replace(sequences, r'^hello$', 'bye'))
 
         self.assertEqual(str(sequences[0].seq), str(transformed.seq))
         self.assertEqual('hello', transformed.id)
         self.assertEqual('hello friend', transformed.description)
 
-    def test_pattern_replace_anchored_match_id_no_description(self):
-        sequences = [seqrecord('hello', 'A')]
-        transformed = next(transform.name_replace(sequences, '^hello$', 'bye'))
+    def test_pattern_replace_anchored_match(self):
+        sequences = [seqrecord('hello', 'A', description='hello friend'),
+                     seqrecord('hello', 'A')]
 
-        self.assertEqual(str(sequences[0].seq), str(transformed.seq))
-        self.assertEqual('bye', transformed.id)
-        self.assertEqual('<unknown description>', transformed.description)
+        transformed = list(transform.name_replace(sequences, r'^hello\b', 'bye'))
+
+        self.assertEqual(str(sequences[0].seq), str(transformed[0].seq))
+        self.assertEqual('bye', transformed[0].id)
+        self.assertEqual('bye friend', transformed[0].description)
+
+        self.assertEqual(str(sequences[1].seq), str(transformed[1].seq))
+        self.assertEqual('bye', transformed[1].id)
+        self.assertEqual('<unknown description>', transformed[1].description)
 
     def test_pattern_replace_none(self):
         result = transform.name_replace(self.sequences, 'ZZZ', 'MATCH')

--- a/seqmagick/transform.py
+++ b/seqmagick/transform.py
@@ -421,7 +421,7 @@ def name_include(records, filter_regex):
                  ' in results.')
     regex = re.compile(filter_regex)
     for record in records:
-        if regex.search(record.description):
+        if regex.search(record.id) or regex.search(record.description):
             yield record
 
 
@@ -434,7 +434,7 @@ def name_exclude(records, filter_regex):
                  'excluding IDs matching ' + filter_regex + ' in results.')
     regex = re.compile(filter_regex)
     for record in records:
-        if not regex.search(record.description):
+        if not regex.search(record.id) and not regex.search(record.description):
             yield record
 
 
@@ -442,13 +442,23 @@ def name_replace(records, search_regex, replace_pattern):
     """
     Given a set of sequences, replace all occurrences of search_regex
     with replace_pattern. Ignore case.
+
+    Substitution is always performed on the sequence ID. If the first "word" of
+    the description matches the ID, assume that the description is FASTA-like
+    and perform substitution only on the "rest" of the description, then add
+    the (possibly modified) ID on front. If the first word does not match the
+    ID, perform substitution on the entire description.
     """
     regex = re.compile(search_regex)
     for record in records:
-        if not record.description.startswith(record.id):
-            record.description = record.id + ' ' + record.description
-        record.description = regex.sub(replace_pattern, record.description)
-        record.id = record.description.split(None, 1)[0]
+        original_id = record.id
+        maybe_id, rest = record.description.split(None, 1)
+        record.id = regex.sub(replace_pattern, record.id)
+        if maybe_id == original_id:
+            rest = regex.sub(replace_pattern, rest)
+            record.description = record.id + ' ' + rest
+        else:
+            record.description = regex.sub(replace_pattern, record.description)
         yield record
 
 

--- a/seqmagick/transform.py
+++ b/seqmagick/transform.py
@@ -451,13 +451,12 @@ def name_replace(records, search_regex, replace_pattern):
     """
     regex = re.compile(search_regex)
     for record in records:
-        original_id = record.id
-        maybe_id, rest = record.description.split(None, 1)
-        record.id = regex.sub(replace_pattern, record.id)
-        if maybe_id == original_id:
-            rest = regex.sub(replace_pattern, rest)
-            record.description = record.id + ' ' + rest
+        maybe_id = record.description.split(None, 1)[0]
+        if maybe_id == record.id:
+            record.description = regex.sub(replace_pattern, record.description)
+            record.id = record.description.split(None, 1)[0]
         else:
+            record.id = regex.sub(replace_pattern, record.id)
             record.description = regex.sub(replace_pattern, record.description)
         yield record
 


### PR DESCRIPTION
See #47; partially reverts 515f55eb7ed2607b3c216ca5c8ced4bae8df51a5.

The sticky part is replacement. This commit's approach:

Substitution is always performed on the sequence ID. If the first "word"
of the description matches the ID, assume that the description is
FASTA-like and perform substitution only on the "rest" of the
description, then add the (possibly modified) ID on front. If the first
word does not match the ID, perform substitution on the entire
description.