### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Use pip::
 Note that as of version 0.7.0, this package requires Python 3.4+. If
 you want to use the most recent version compatible with Python 2.7::
 
-  pip install seqmagick==1.6.2
+  pip install seqmagick==0.6.2
 
 Features
 ========


### PR DESCRIPTION
The version number shown in pip installation block is wrong. 
Should be pip install seqmagick==0.6.2, instead of 1.6.2