### PR TITLE
Send logging to stderr, not stdout

### DIFF
--- a/seqmagick/scripts/cli.py
+++ b/seqmagick/scripts/cli.py
@@ -24,7 +24,7 @@ def main(argv=sys.argv[1:]):
         logformat = '%(message)s'
 
     # set up logging
-    logging.basicConfig(stream=sys.stdout, format=logformat, level=loglevel)
+    logging.basicConfig(stream=sys.stderr, format=logformat, level=loglevel)
 
     return action(arguments)
 


### PR DESCRIPTION
In order to support Unix piping and redirection, any error messages and logging should go to stderr,
only data should go to stdout.

Should close issue #74

(Change currently untested.)