### PR TITLE
Fix for Biopython 1.71 dual coding support

### DIFF
--- a/seqmagick/transform.py
+++ b/seqmagick/transform.py
@@ -668,6 +668,10 @@ class CodonWarningTable(object):
         else:
             return self.wrapped.__getitem__(codon)
 
+    def __contains__(self, value):
+        return value in self.wrapped
+
+
 def translate(records, translate):
     """
     Perform translation from generic DNA/RNA to proteins.  Bio.Seq


### PR DESCRIPTION
This should close issue #73, indirectly triggered by changes in Biopython to support recent NCBI codon tables with codons which can be amino acids of stop codons.

Previously the monkey-patched sub-class was breaking here:

```python
dual_coding = [c for c in stop_codons if c in forward_table]
```

This change adds direct support for ``__contains__`` by forwarding this to the wrapped forward table.