### PR TITLE
Encode hash result in hash_starts_numeric

### DIFF
--- a/examples/apply-function/myfunctions.py
+++ b/examples/apply-function/myfunctions.py
@@ -14,6 +14,6 @@ def hash_starts_numeric(records):
     their sha-1 hash.
     """
     for record in records:
-        seq_hash = hashlib.sha1(str(record.seq)).hexdigest()
+        seq_hash = hashlib.sha1(str(record.seq).encode('utf-8')).hexdigest()
         if seq_hash[0].isdigit():
             yield record


### PR DESCRIPTION
run_filter.sh ends up with the following:

```
Traceback (most recent call last):
  File "/usr/bin/seqmagick", line 11, in <module>
    load_entry_point('seqmagick==0.0.0', 'console_scripts', 'seqmagick')()
  File "/usr/lib/python3/dist-packages/seqmagick/scripts/cli.py", line 29, in main
    return action(arguments)
  File "/usr/lib/python3/dist-packages/seqmagick/subcommands/convert.py", line 354, in action
    transform_file(src, dest, arguments)
  File "/usr/lib/python3/dist-packages/seqmagick/subcommands/convert.py", line 318, in transform_file
    SeqIO.write(records, destination_file, destination_file_type)
  File "/usr/lib/python3/dist-packages/Bio/SeqIO/__init__.py", line 556, in write
    for record in sequences:
  File "myfunctions.py", line 17, in hash_starts_numeric
    seq_hash = hashlib.sha1(str(record.seq)).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```
This is an attempt to fix it.