### PR TITLE
quick patch changing biopython requirement to 1.77

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-biopython>=1.70
+biopython==1.77
 pygtrie
 
 # for development

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='seqmagick',
       setup_requires=['nose>=1.0'],
       python_requires='>=3.5',
       test_suite='nose.collector',
-      install_requires=['biopython>=1.70'],
+      install_requires=['biopython==1.77', 'pygtrie'],
       classifiers=[
           'License :: OSI Approved :: GNU General Public License (GPL)',
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
This should resolve requirements to keep Bio.Alphabet code infrastructure. Ultimately, we should be replacing the code like https://biopython.org/wiki/Alphabet .

This is in response to #87 