### PR TITLE
Proposal for Biopython 1.78 compatibility

### DIFF
--- a/seqmagick/subcommands/convert.py
+++ b/seqmagick/subcommands/convert.py
@@ -223,6 +223,11 @@ def build_parser(parser):
 
     return parser
 
+def append_annotation_iterator(records_iterator):
+    for record in records_iterator:
+        record.annotations["molecule_type"] = "DNA"
+        yield record
+
 def transform_file(source_file, destination_file, arguments):
     # Get just the file name, useful for naming the temporary file.
     source_file_type = (arguments.input_format or from_handle(source_file))
@@ -307,13 +312,8 @@ def transform_file(source_file, destination_file, arguments):
         # loading the entire sequence file up into memory.
         logging.info("Applying transformations, writing to %s",
                 destination_file)
-        # FIXME: to put annotations, all records are loaded in memory, which
-        #        beats the purpose of the previous comment.
-        newrecords = list()
-        for record in records:
-            record.annotations["molecule_type"] = "DNA"
-            newrecords += [record]
-        SeqIO.write(newrecords, destination_file, destination_file_type)
+        records = append_annotation_iterator(records)
+        SeqIO.write(records, destination_file, destination_file_type)
 
 
 def module_function(string):

--- a/seqmagick/subcommands/convert.py
+++ b/seqmagick/subcommands/convert.py
@@ -6,8 +6,7 @@ import functools
 import logging
 import random
 
-from Bio import Alphabet, SeqIO
-from Bio.Alphabet import IUPAC
+from Bio import SeqIO
 from Bio.SeqIO import FastaIO
 from seqmagick import transform
 from seqmagick.fileformat import from_handle
@@ -15,11 +14,11 @@ from seqmagick.fileformat import from_handle
 from . import common
 
 ALPHABETS = {
-        'dna': Alphabet.generic_dna,
-        'dna-ambiguous': IUPAC.ambiguous_dna,
-        'protein': Alphabet.generic_protein,
-        'rna': Alphabet.generic_rna,
-        'rna-ambiguous': IUPAC.ambiguous_rna,
+        'dna': 'DNA',
+        'dna-ambiguous': 'DNA-ambiguous',
+        'protein': 'protein',
+        'rna': 'RNA',
+        'rna-ambiguous': 'RNA-ambiguous',
 }
 
 def add_options(parser):
@@ -249,8 +248,7 @@ def transform_file(source_file, destination_file, arguments):
                 direction=directions[direction])
     else:
         # Unsorted iterator.
-        records = SeqIO.parse(source_file, source_file_type,
-                alphabet=ALPHABETS.get(arguments.alphabet))
+        records = SeqIO.parse(source_file, source_file_type)
 
 
     #########################################
@@ -315,7 +313,13 @@ def transform_file(source_file, destination_file, arguments):
         # loading the entire sequence file up into memory.
         logging.info("Applying transformations, writing to %s",
                 destination_file)
-        SeqIO.write(records, destination_file, destination_file_type)
+        # FIXME: to put annotations, all records are loaded in memory, which
+        #        beats the purpose of the previous comment.
+        newrecords = list()
+        for record in records:
+            record.annotations["molecule_type"] = "DNA"
+            newrecords += [record]
+        SeqIO.write(newrecords, destination_file, destination_file_type)
 
 
 def module_function(string):

--- a/seqmagick/subcommands/convert.py
+++ b/seqmagick/subcommands/convert.py
@@ -13,14 +13,6 @@ from seqmagick.fileformat import from_handle
 
 from . import common
 
-ALPHABETS = {
-        'dna': 'DNA',
-        'dna-ambiguous': 'DNA-ambiguous',
-        'protein': 'protein',
-        'rna': 'RNA',
-        'rna-ambiguous': 'RNA-ambiguous',
-}
-
 def add_options(parser):
     """
     Add optional arguments to the parser
@@ -212,8 +204,10 @@ def add_options(parser):
     format_group.add_argument('--output-format', metavar='FORMAT',
             help="Output file format (default: determine from extension)")
 
-    parser.add_argument('--alphabet', choices=ALPHABETS,
-            help="""Input alphabet. Required for writing NEXUS.""")
+    parser.add_argument('--alphabet', help="""Input alphabet. Formerly required
+            for writing NEXUS, this option is now ignored for compatibility with
+            Biopython 1.78 and greater, and provided for compatibility with
+            existing scripts.""")
 
     return parser
 

--- a/seqmagick/subcommands/primer_trim.py
+++ b/seqmagick/subcommands/primer_trim.py
@@ -7,8 +7,7 @@ import logging
 import operator
 import sys
 
-from Bio import Alphabet, SeqIO, pairwise2
-from Bio.Alphabet import IUPAC
+from Bio import SeqIO, pairwise2
 from Bio.Seq import Seq
 
 from seqmagick import transform, fileformat
@@ -298,8 +297,7 @@ def action(arguments):
     with arguments.source_file:
         sequences = SeqIO.parse(
             arguments.source_file,
-            source_format,
-            alphabet=Alphabet.Gapped(Alphabet.single_letter_alphabet))
+            source_format)
 
         # Locate primers
         (forward_start, forward_end), (reverse_start, reverse_end) = locate_primers(
@@ -319,8 +317,7 @@ def action(arguments):
         arguments.source_file.seek(0)
         sequences = SeqIO.parse(
             arguments.source_file,
-            source_format,
-            alphabet=Alphabet.Gapped(Alphabet.single_letter_alphabet))
+            source_format)
 
         # Apply the transformation
         prune_action = _ACTIONS[arguments.prune_action]

--- a/seqmagick/test/integration/data/input6.fasta
+++ b/seqmagick/test/integration/data/input6.fasta
@@ -1,0 +1,6 @@
+>test1 test sequence 1 RNA
+AC-GU
+>test2 test sequence 2
+A-AAA
+>test3 sequence 3
+A---A

--- a/seqmagick/test/integration/data/output2.nex
+++ b/seqmagick/test/integration/data/output2.nex
@@ -1,7 +1,7 @@
 #NEXUS
 begin data;
-	dimensions ntax=3 nchar=5;
-	format datatype=dna missing=? gap=-;
+dimensions ntax=3 nchar=5;
+format datatype=dna missing=? gap=-;
 matrix
 test1 AC-GT
 test2 A-AAA

--- a/seqmagick/test/integration/data/output3.nex
+++ b/seqmagick/test/integration/data/output3.nex
@@ -1,0 +1,10 @@
+#NEXUS
+begin data;
+dimensions ntax=3 nchar=5;
+format datatype=rna missing=? gap=-;
+matrix
+test1 AC-GU
+test2 A-AAA
+test3 A---A
+;
+end;

--- a/seqmagick/test/integration/data/output4.nex
+++ b/seqmagick/test/integration/data/output4.nex
@@ -1,0 +1,10 @@
+#NEXUS
+begin data;
+dimensions ntax=3 nchar=5;
+format datatype=protein missing=? gap=-;
+matrix
+test1 AC-GT
+test2 A-AAA
+test3 A---A
+;
+end;

--- a/seqmagick/test/integration/test_convert.py
+++ b/seqmagick/test/integration/test_convert.py
@@ -97,6 +97,20 @@ class ConvertToNexusTestCase(CommandLineTestMixIn, unittest.TestCase):
     command = 'convert {input} {output} --output-format nexus --alphabet dna-ambiguous'
 
 
+class ConvertToNexusRNATestCase(CommandLineTestMixIn, unittest.TestCase):
+    in_suffix = '.fasta'
+    input_path = p('input6.fasta')
+    expected_path = p('output3.nex')
+    command = 'convert {input} {output} --output-format nexus --alphabet rna'
+
+
+class ConvertToNexusProteinTestCase(CommandLineTestMixIn, unittest.TestCase):
+    in_suffix = '.fasta'
+    input_path = p('input2.fasta')
+    expected_path = p('output4.nex')
+    command = 'convert {input} {output} --output-format nexus --alphabet protein'
+
+
 class ConvertUngapCutTestCase(CommandLineTestMixIn, unittest.TestCase):
     in_suffix = '.fasta'
     out_suffix = '.fasta'

--- a/seqmagick/test/test_primer_trim.py
+++ b/seqmagick/test/test_primer_trim.py
@@ -3,7 +3,6 @@ Tests for primer trim
 """
 import unittest
 
-from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -70,8 +69,7 @@ class HammingDistanceTestCase(unittest.TestCase):
 
 
 def _alignment_record(sequence):
-    return SeqRecord(
-        Seq(sequence, alphabet=Alphabet.Gapped(Alphabet.generic_dna)))
+    return SeqRecord(Seq(sequence))
 
 
 class LocatePrimersTestCase(unittest.TestCase):

--- a/seqmagick/test/test_transform.py
+++ b/seqmagick/test/test_transform.py
@@ -7,7 +7,7 @@ import functools
 import logging
 import unittest
 
-from Bio import Alphabet, SeqIO
+from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq
 
@@ -16,16 +16,13 @@ from seqmagick import transform
 logging.basicConfig(level=logging.FATAL)
 
 def _alignment_record(sequence):
-    return SeqRecord(Seq(sequence,
-        alphabet=Alphabet.Gapped(Alphabet.generic_dna)))
+    return SeqRecord(Seq(sequence))
 
-def seqrecord(sequence_id, sequence_text, alphabet=Alphabet.generic_dna,
-              description=None):
+def seqrecord(sequence_id, sequence_text, description=None):
     """
     Quick shortcut to make a SeqRecord
     """
-    record = SeqRecord(Seq(sequence_text, alphabet),
-                       id=sequence_id)
+    record = SeqRecord(Seq(sequence_text), id=sequence_id)
     if description:
         record.description = description
     return record

--- a/seqmagick/transform.py
+++ b/seqmagick/transform.py
@@ -13,7 +13,6 @@ import tempfile
 import random
 
 from Bio import SeqIO
-from Bio.Alphabet import IUPAC
 from Bio.Data import CodonTable
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -63,8 +62,7 @@ def dashes_cleanup(records, prune_chars='.:?~'):
         "Applying _dashes_cleanup: converting any of '{}' to '-'.".format(prune_chars))
     translation_table = {ord(c): '-' for c in prune_chars}
     for record in records:
-        record.seq = Seq(str(record.seq).translate(translation_table),
-                         record.seq.alphabet)
+        record.seq = Seq(str(record.seq).translate(translation_table))
         yield record
 
 
@@ -169,8 +167,7 @@ def isolate_region(sequences, start, end, gap_char='-'):
         seq = sequence.seq
         start_gap = gap_char * start
         end_gap = gap_char * (len(seq) - end)
-        seq = Seq(start_gap + str(seq[start:end]) + end_gap,
-                alphabet=seq.alphabet)
+        seq = Seq(start_gap + str(seq[start:end]) + end_gap)
         sequence.seq = seq
         yield sequence
 
@@ -191,7 +188,7 @@ def drop_columns(records, slices):
         drop = set(i for slice in slices
                    for i in range(*slice.indices(len(record))))
         keep = [i not in drop for i in range(len(record))]
-        record.seq = Seq(''.join(itertools.compress(record.seq, keep)), record.seq.alphabet)
+        record.seq = Seq(''.join(itertools.compress(record.seq, keep)))
         yield record
 
 def multi_cut_sequences(records, slices):
@@ -690,7 +687,6 @@ def translate(records, translate):
     to_stop = translate.endswith('stop')
 
     source_type = translate[:3]
-    alphabet = {'dna': IUPAC.ambiguous_dna, 'rna': IUPAC.ambiguous_rna}[source_type]
 
     # Get a translation table
     table = {'dna': CodonTable.ambiguous_dna_by_name["Standard"],
@@ -704,7 +700,7 @@ def translate(records, translate):
 
     for record in records:
         sequence = str(record.seq)
-        seq = Seq(sequence, alphabet)
+        seq = Seq(sequence)
         protein = seq.translate(table, to_stop=to_stop)
         yield SeqRecord(protein, id=record.id, description=record.description)
 


### PR DESCRIPTION
Greetings,

Since future versions of Debian and Ubuntu are likely to be released with Biopython 1.78 or greater, I have been devising on a patch to address issue #87, which you will find in this merge request.

I tried to make sure the test suite was passing as expected, and it led to a change I'm half happy with; see the FIXME in seqmagick/subcommands/convert.py.  Also, some reference data had to be updated due to a change in the Nexus file output in Biopython 1.78.

I have been following recommendations from https://biopython.org/wiki/Alphabet rather naively I believe, so take the commits with an adequate grain of salt, as always.

Have a nice day,  :)
Étienne.