### PR TITLE
Port Seq.ungap call to Biopython 1.80.

### DIFF
--- a/seqmagick/subcommands/backtrans_align.py
+++ b/seqmagick/subcommands/backtrans_align.py
@@ -102,7 +102,7 @@ class AlignmentMapper(object):
                 prot_seq.id, nucl_seq.id)
 
         # Ungap nucleotides
-        codons = batch(str(nucl_seq.seq.ungap('-')), 3)
+        codons = batch(str(nucl_seq.seq.replace('-', '')), 3)
         codons = [''.join(i) for i in codons]
         codon_iter = iter(codons)
 


### PR DESCRIPTION
Since Biopython 1.80, the call to Seq.ungap(gap) is deprecated and replaced by Seq.replace(gap, '').  Sticking to ungap is currently causing [Debian bug #1066772].  This change allows running ungap workloads with Biopython versions 1.80 and newer.

[Debian bug #1066772]: https://bugs.debian.org/1066772